### PR TITLE
fixed : Searching for a location in Autocomplete search bar and selecting it , makes the floating card shows loading indicator infinitely - IOS Specific

### DIFF
--- a/lib/src/google_map_place_picker.dart
+++ b/lib/src/google_map_place_picker.dart
@@ -300,6 +300,10 @@ class GoogleMapPlacePicker extends StatelessWidget {
   }
 
   Widget _defaultPlaceWidgetBuilder(BuildContext context, PickResult data, SearchingState state) {
+    bool changeStateManually = false;
+    if (data != null){changeStateManually = true;}
+    else{changeStateManually = false;}
+    
     return FloatingCard(
       bottomPosition: MediaQuery.of(context).size.height * 0.05,
       leftPosition: MediaQuery.of(context).size.width * 0.025,
@@ -308,7 +312,7 @@ class GoogleMapPlacePicker extends StatelessWidget {
       borderRadius: BorderRadius.circular(12.0),
       elevation: 4.0,
       color: Theme.of(context).cardColor,
-      child: state == SearchingState.Searching ? _buildLoadingIndicator() : _buildSelectionDetails(context, data),
+      child: state == SearchingState.Searching && changeStateManually == false ? _buildLoadingIndicator() : _buildSelectionDetails(context, data),
     );
   }
 


### PR DESCRIPTION
we have a problem in the IOS platform ... which is  
> The Floating card shows the loading indicator infinitely when I search for a location in the search bar and selecting it.
I could see that the SearchingState is not set to Idle after a location is found.
But the floating card works perfectly when the pin is moved and the selected location is shown correctly

related issue  https://github.com/fysoul17/google_maps_place_picker/issues/68