### PR TITLE
Add to support app restricted API keys

### DIFF
--- a/lib/providers/place_provider.dart
+++ b/lib/providers/place_provider.dart
@@ -12,17 +12,24 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 class PlaceProvider extends ChangeNotifier {
-  PlaceProvider(String apiKey, String proxyBaseUrl, Client httpClient) {
+  PlaceProvider(
+    String apiKey,
+    String proxyBaseUrl,
+    Client httpClient,
+    Map<String, dynamic> apiHeaders,
+  ) {
     places = GoogleMapsPlaces(
       apiKey: apiKey,
       baseUrl: proxyBaseUrl,
       httpClient: httpClient,
+      apiHeaders: apiHeaders,
     );
 
     geocoding = GoogleMapsGeocoding(
       apiKey: apiKey,
       baseUrl: proxyBaseUrl,
       httpClient: httpClient,
+      apiHeaders: apiHeaders,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   geolocator: ^6.0.0+4
   permission_handler: ^5.0.1+1
   provider: ^4.0.1
-  google_maps_webservice: ^0.0.16
+  google_api_headers: ">=0.1.0 <1.0.0"
+  google_maps_webservice: ^0.0.19
   tuple: ^1.0.3
   http: ^0.12.0+4
 


### PR DESCRIPTION
- Add [`google_api_headers`](https://pub.dev/packages/google_api_headers) as a dependency which provides the required headers for making API calls using app restricted API keys
- Add to support API keys that are restricted to iOS or Android apps
- Update `google_maps_webservice` to minimum version `0.0.19` for supporting custom API headers
- Related issues: #61 #62 