### PR TITLE
fix for suggestion list not disappearing #57

### DIFF
--- a/lib/src/autocomplete_search.dart
+++ b/lib/src/autocomplete_search.dart
@@ -91,6 +91,7 @@ class AutoCompleteSearchState extends State<AutoCompleteSearch> {
 
     focus.removeListener(_onFocusChanged);
     focus.dispose();
+    _clearOverlay();
 
     super.dispose();
   }


### PR DESCRIPTION
This is a fix for the suggestion list not disappearing when users press "Select here" while it is displayed. 

related issue #57