### PR TITLE
Fix permanent loading indicator

### DIFF
--- a/lib/src/google_map_place_picker.dart
+++ b/lib/src/google_map_place_picker.dart
@@ -168,6 +168,7 @@ class GoogleMapPlacePicker extends StatelessWidget {
               if (provider.isAutoCompleteSearching) {
                 provider.isAutoCompleteSearching = false;
                 provider.pinState = PinState.Idle;
+                provider.placeSearchingState = SearchingState.Idle;
                 return;
               }
 


### PR DESCRIPTION
Fix permanent loading indicator when using search bar on iOS. Fixes #124.

#76 will cause some weird behavior when moving the pin. It will show the old address until the new one is load, so this was not really a fix. However, the key is to set it the SearchingState to Idle after completing the search through the AutoCompleteSearch, which I've done in this PR.